### PR TITLE
Optimize to single tf call

### DIFF
--- a/validator/main.py
+++ b/validator/main.py
@@ -97,7 +97,7 @@ class RestrictToTopic(Validator):
         else:
             self._invalid_topics = invalid_topics
 
-        self._device = device if device in ["cpu", "mps"] else to_int(device)
+        self._device = device if device == "mps" else to_int(device)
         self._model = model
         self._disable_classifier = disable_classifier
         self._disable_llm = disable_llm
@@ -118,7 +118,7 @@ class RestrictToTopic(Validator):
             if score > self._model_threshold and topic in self._valid_topics:
                 succesfully_on_topic.append(topic)
             if score > self._model_threshold and topic in self._invalid_topics:
-                return FailResult(error_message=f"Invalid {topic} was found to be relevant.")
+                return FailResult(error_message=f"Invalid topic {topic} was found to be relevant.")
         if not succesfully_on_topic:
             return FailResult(error_message="No valid topic was found.")
         return self.get_topic_llm(text, candidate_topics)
@@ -211,7 +211,7 @@ class RestrictToTopic(Validator):
         classifier = pipeline(
             "zero-shot-classification",
             model=self._model,
-            device=self._device,
+            device="mps",
             hypothesis_template="This example has to do with topic {}.",
             multi_label=True
         )

--- a/validator/main.py
+++ b/validator/main.py
@@ -76,7 +76,7 @@ class RestrictToTopic(Validator):
         self,
         valid_topics: List[str],
         invalid_topics: Optional[List[str]] = [],
-        device: Optional[int] = -1,
+        device: Optional[Union[str, int]] = -1,
         model: Optional[str] = "facebook/bart-large-mnli",
         llm_callable: Union[str, Callable, None] = None,
         disable_classifier: Optional[bool] = False,
@@ -106,7 +106,9 @@ class RestrictToTopic(Validator):
         else:
             self._invalid_topics = invalid_topics
 
-        self._device = device if device == "mps" else to_int(device)
+        self._device = (
+            device.lower() if device.lower() in ["cpu", "mps"] else int(device)
+        )
         self._model = model
         self._disable_classifier = disable_classifier
         self._disable_llm = disable_llm

--- a/validator/main.py
+++ b/validator/main.py
@@ -97,7 +97,7 @@ class RestrictToTopic(Validator):
         else:
             self._invalid_topics = invalid_topics
 
-        self._device = device if device == "mps" else to_int(device)
+        self._device = device if device in ["cpu", "mps"] else to_int(device)
         self._model = model
         self._disable_classifier = disable_classifier
         self._disable_llm = disable_llm
@@ -211,7 +211,7 @@ class RestrictToTopic(Validator):
         classifier = pipeline(
             "zero-shot-classification",
             model=self._model,
-            device="mps",
+            device=self._device,
             hypothesis_template="This example has to do with topic {}.",
             multi_label=True
         )

--- a/validator/main.py
+++ b/validator/main.py
@@ -97,7 +97,7 @@ class RestrictToTopic(Validator):
         else:
             self._invalid_topics = invalid_topics
 
-        self._device = device if device == "mps" else to_int(device)
+        self._device = device if device in ["cpu", "mps"] else to_int(device)
         self._model = model
         self._disable_classifier = disable_classifier
         self._disable_llm = disable_llm
@@ -118,7 +118,9 @@ class RestrictToTopic(Validator):
             if score > self._model_threshold and topic in self._valid_topics:
                 succesfully_on_topic.append(topic)
             if score > self._model_threshold and topic in self._invalid_topics:
-                return FailResult(error_message=f"Invalid topic {topic} was found to be relevant.")
+                return FailResult(
+                    error_message=f"Invalid topic {topic} was found to be relevant."
+                )
         if not succesfully_on_topic:
             return FailResult(error_message="No valid topic was found.")
         return self.get_topic_llm(text, candidate_topics)
@@ -211,9 +213,9 @@ class RestrictToTopic(Validator):
         classifier = pipeline(
             "zero-shot-classification",
             model=self._model,
-            device="mps",
+            device=self._device,
             hypothesis_template="This example has to do with topic {}.",
-            multi_label=True
+            multi_label=True,
         )
         result = classifier(text, candidate_topics)
         topics = result["labels"]
@@ -236,7 +238,6 @@ class RestrictToTopic(Validator):
         if bool(valid_topics.intersection(invalid_topics)):
             raise ValueError("A topic cannot be valid and invalid at the same time.")
 
-
         # Check which model(s) to use
         if self._disable_classifier and self._disable_llm:  # Error, no model set
             raise ValueError("Either classifier or llm must be enabled.")
@@ -248,13 +249,17 @@ class RestrictToTopic(Validator):
             return self.get_topic_llm(value, list(invalid_topics))
 
         # Use only Zero-Shot
-        topics, scores = self.get_topic_zero_shot(value, list(invalid_topics) + list(valid_topics))
+        topics, scores = self.get_topic_zero_shot(
+            value, list(invalid_topics) + list(valid_topics)
+        )
         succesfully_on_topic = []
         for score, topic in zip(scores, topics):
             if score > self._model_threshold and topic in self._valid_topics:
                 succesfully_on_topic.append(topic)
             if score > self._model_threshold and topic in self._invalid_topics:
-                return FailResult(error_message=f"Invalid {topic} was found to be relevant.")
+                return FailResult(
+                    error_message=f"Invalid {topic} was found to be relevant."
+                )
         if not succesfully_on_topic:
             return FailResult(error_message="No valid topic was found.")
         return PassResult()

--- a/validator/main.py
+++ b/validator/main.py
@@ -16,7 +16,7 @@ from transformers import pipeline
 
 
 @register_validator(name="tryolabs/restricttotopic", data_type="string")
-class RestrictToTopic(Validator):  # type: ignore
+class RestrictToTopic(Validator):
     """Checks if text's main topic is specified within a list of valid topics
     and ensures that the text is not about any of the invalid topics.
 
@@ -234,7 +234,10 @@ class RestrictToTopic(Validator):  # type: ignore
             raise ValueError(
                 "`valid_topics` must be set and contain at least one topic."
             )
-
+        if not invalid_topics:
+            raise ValueError(
+                "`invalid topics` must be set and contain at least one topic."
+            )
         # throw if valid and invalid topics are not disjoint
         if bool(valid_topics.intersection(invalid_topics)):
             raise ValueError("A topic cannot be valid and invalid at the same time.")

--- a/validator/main.py
+++ b/validator/main.py
@@ -132,7 +132,19 @@ class RestrictToTopic(Validator):
             self._valid_topics, self._invalid_topics
         )
 
-    def _create_json_schema(self, valid_topics: list, invalid_topics: list):
+    def _create_json_schema(self, valid_topics: list, invalid_topics: list) -> str:
+        """Creates a json schema that an LLM will fill out. The json schema contains
+        one of each of the provided topics, as well as a blank 'present' and 'confidence'
+        for the llm to fill in.
+
+        Args:
+            valid_topics (list): The valid topics to provide as one of the json schema
+            invalid_topics (list): Invalid topics to provide as one of the json schema
+
+        Returns:
+            str: The resulting json schema with unfilled data types
+        """
+
         json_schema = []
         for topic in set(valid_topics + invalid_topics):
             json_schema.append(
@@ -159,7 +171,17 @@ class RestrictToTopic(Validator):
 
         return list(set(zero_shot_topics + llm_topics))
 
-    def get_topic_llm(self, text: str, candidate_topics: List[str]) -> ValidationResult:
+    def get_topic_llm(self, text: str, candidate_topics: List[str]) -> list[str]:
+        """Returns a list of the topics identified in the given text using an LLM
+        callable
+
+        Args:
+            text (str): The input text to classify topics.
+            candidate_topics (List[str]): The topics to identify if present in the text.
+
+        Returns:
+            list[str]: The topics found in the input text.
+        """
         response = self.call_llm(text)
         topics = json.loads(response)
         found_topics = []
@@ -171,6 +193,11 @@ class RestrictToTopic(Validator):
         return found_topics
 
     def get_client_args(self) -> Tuple[Optional[str], Optional[str]]:
+        """Returns neccessary data for api calls.
+
+        Returns:
+            Tuple[Optional[str], Optional[str]]: api key and api base values
+        """
         kwargs = {}
         context_copy = contextvars.copy_context()
         for key, context_var in context_copy.items():

--- a/validator/main.py
+++ b/validator/main.py
@@ -157,7 +157,7 @@ class RestrictToTopic(Validator):
             )
         return str(json_schema)
 
-    def get_topic_ensemble(self, text: str, candidate_topics: List[str]) -> list[str]:
+    def get_topics_ensemble(self, text: str, candidate_topics: List[str]) -> list[str]:
         """Finds the topics in the input text based on if it is determined by the zero
         shot model or the llm.
 
@@ -169,14 +169,14 @@ class RestrictToTopic(Validator):
             list[str]: The found topics
         """
         # Find topics based on zero shot model
-        zero_shot_topics = self.get_topic_zero_shot(text, candidate_topics)
+        zero_shot_topics = self.get_topics_zero_shot(text, candidate_topics)
 
         # Find topics based on llm
-        llm_topics = self.get_topic_llm(text, candidate_topics)
+        llm_topics = self.get_topics_llm(text, candidate_topics)
 
         return list(set(zero_shot_topics + llm_topics))
 
-    def get_topic_llm(self, text: str, candidate_topics: List[str]) -> list[str]:
+    def get_topics_llm(self, text: str, candidate_topics: List[str]) -> list[str]:
         """Returns a list of the topics identified in the given text using an LLM
         callable
 
@@ -284,7 +284,7 @@ class RestrictToTopic(Validator):
         else:
             raise ValueError("llm_callable must be a string or a Callable")
 
-    def get_topic_zero_shot(self, text: str, candidate_topics: List[str]) -> list[str]:
+    def get_topics_zero_shot(self, text: str, candidate_topics: List[str]) -> list[str]:
         """Gets the topics found through the zero shot classifier
 
         Args:
@@ -337,13 +337,13 @@ class RestrictToTopic(Validator):
 
         # Ensemble method
         if not self._disable_classifier and not self._disable_llm:
-            found_topics = self.get_topics_ensemble(value, invalid_topics)
+            found_topics = self.get_topics_ensemble(value, all_topics)
         # LLM Classifier Only
         elif self._disable_classifier and not self._disable_llm:
-            found_topics = self.get_topics_llm(value, invalid_topics)
+            found_topics = self.get_topics_llm(value, all_topics)
         # Zero Shot Classifier Only
         elif not self._disable_classifier and self._disable_llm:
-            found_topics, _ = self.get_topic_zero_shot(value, invalid_topics)
+            found_topics = self.get_topics_zero_shot(value, all_topics)
         else:
             raise ValueError("Either classifier or llm must be enabled.")
 

--- a/validator/main.py
+++ b/validator/main.py
@@ -181,11 +181,11 @@ class RestrictToTopic(Validator):
 
         return (api_key, api_base)
 
-    # @retry(
-    #     wait=wait_random_exponential(min=1, max=60),
-    #     stop=stop_after_attempt(5),
-    #     reraise=True,
-    # )
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(5),
+        reraise=True,
+    )
     def call_llm(self, text: str, topics: List[str]) -> str:
         """Call the LLM with the given prompt.
 
@@ -301,19 +301,19 @@ class RestrictToTopic(Validator):
         if bool(valid_topics.intersection(invalid_topics)):
             raise ValueError("A topic cannot be valid and invalid at the same time.")
 
-        # Check which model(s) to use
+        # Verify at least one is enabled
         if self._disable_classifier and self._disable_llm:  # Error, no model set
             raise ValueError("Either classifier or llm must be enabled.")
 
-        # Use ensemble (Zero-Shot + Ensemble)
+        # Case: both enabled/ensemble (Zero-Shot + Ensemble)
         elif not self._disable_classifier and not self._disable_llm:
             found_topics = self.get_topic_ensemble(value, all_topics)
 
-        # Use only LLM
+        # Case: Only use LLM
         elif self._disable_classifier and not self._disable_llm:
             found_topics = self.get_topic_llm(value, all_topics)
 
-        # Use only Zero-Shot
+        # Case: Only use Zero-Shot
         elif not self._disable_classifier and self._disable_llm:
             found_topics = self.get_topic_zero_shot(value, all_topics)
 

--- a/validator/main.py
+++ b/validator/main.py
@@ -16,7 +16,7 @@ from transformers import pipeline
 
 
 @register_validator(name="tryolabs/restricttotopic", data_type="string")
-class RestrictToTopic(Validator):
+class RestrictToTopic(Validator):  # type: ignore
     """Checks if text's main topic is specified within a list of valid topics
     and ensures that the text is not about any of the invalid topics.
 

--- a/validator/main.py
+++ b/validator/main.py
@@ -108,6 +108,13 @@ class RestrictToTopic(Validator):
             self._model_threshold = model_threshold
 
         self.set_callable(llm_callable)
+        self.classifier = pipeline(
+            "zero-shot-classification",
+            model=self._model,
+            device=self._device,
+            hypothesis_template="This example has to do with topic {}.",
+            multi_label=True,
+        )
 
     def get_topic_ensemble(
         self, text: str, candidate_topics: List[str]
@@ -210,14 +217,8 @@ class RestrictToTopic(Validator):
     def get_topic_zero_shot(
         self, text: str, candidate_topics: List[str]
     ) -> Tuple[str, float]:
-        classifier = pipeline(
-            "zero-shot-classification",
-            model=self._model,
-            device=self._device,
-            hypothesis_template="This example has to do with topic {}.",
-            multi_label=True,
-        )
-        result = classifier(text, candidate_topics)
+
+        result = self.classifier(text, candidate_topics)
         topics = result["labels"]
         scores = result["scores"]
         return topics, scores

--- a/validator/main.py
+++ b/validator/main.py
@@ -335,21 +335,17 @@ class RestrictToTopic(Validator):
         if bool(valid_topics.intersection(invalid_topics)):
             raise ValueError("A topic cannot be valid and invalid at the same time.")
 
-        # Verify at least one is enabled
-        if self._disable_classifier and self._disable_llm:  # Error, no model set
-            raise ValueError("Either classifier or llm must be enabled.")
-
-        # Case: both enabled/ensemble (Zero-Shot + Ensemble)
-        elif not self._disable_classifier and not self._disable_llm:
-            found_topics = self.get_topic_ensemble(value, all_topics)
-
-        # Case: Only use LLM
+        # Ensemble method
+        if not self._disable_classifier and not self._disable_llm:
+            found_topics = self.get_topics_ensemble(value, invalid_topics)
+        # LLM Classifier Only
         elif self._disable_classifier and not self._disable_llm:
-            found_topics = self.get_topic_llm(value, all_topics)
-
-        # Case: Only use Zero-Shot
+            found_topics = self.get_topics_llm(value, invalid_topics)
+        # Zero Shot Classifier Only
         elif not self._disable_classifier and self._disable_llm:
-            found_topics = self.get_topic_zero_shot(value, all_topics)
+            found_topics, _ = self.get_topic_zero_shot(value, invalid_topics)
+        else:
+            raise ValueError("Either classifier or llm must be enabled.")
 
         # Determine if valid or invalid topics were found
         invalid_topics_found = []

--- a/validator/main.py
+++ b/validator/main.py
@@ -234,10 +234,7 @@ class RestrictToTopic(Validator):
             raise ValueError(
                 "`valid_topics` must be set and contain at least one topic."
             )
-        if not invalid_topics:
-            raise ValueError(
-                "`invalid topics` must be set and contain at least one topic."
-            )
+
         # throw if valid and invalid topics are not disjoint
         if bool(valid_topics.intersection(invalid_topics)):
             raise ValueError("A topic cannot be valid and invalid at the same time.")
@@ -247,10 +244,12 @@ class RestrictToTopic(Validator):
             raise ValueError("Either classifier or llm must be enabled.")
         elif (
             not self._disable_classifier and not self._disable_llm
-        ):  # Use ensemble (Zero-Shot + Ensemble)
-            return self.get_topic_ensemble(value, list(invalid_topics))
+        ):  
+            if invalid_topics:# Use ensemble (Zero-Shot + Ensemble)
+                return self.get_topic_ensemble(value, list(invalid_topics))
         elif self._disable_classifier and not self._disable_llm:  # Use only LLM
-            return self.get_topic_llm(value, list(invalid_topics))
+            if invalid_topics:
+                return self.get_topic_llm(value, list(invalid_topics))
 
         # Use only Zero-Shot
         topics, scores = self.get_topic_zero_shot(

--- a/validator/main.py
+++ b/validator/main.py
@@ -59,12 +59,17 @@ class RestrictToTopic(Validator):
         disable_classifier (bool, Optional, defaults to False): controls whether
             to use the Zero-Shot model. At least one of disable_classifier and
             disable_llm must be False.
+        classifier_api_endpoint (str, Optional, defaults to None): An API endpoint
+            to recieve post requests that will be used when provided. If not provided, a
+            local model will be initialized.
         disable_llm (bool, Optional, defaults to False): controls whether to use
             the LLM fallback. At least one of disable_classifier and
             disable_llm must be False.
-        model_threshold (float, Optional, defaults to 0.5): The threshold used to
+        zero_shot_threshold (float, Optional, defaults to 0.5): The threshold used to
             determine whether to accept a topic from the Zero-Shot model. Must be
             a number between 0 and 1.
+        llm_threshold (int, Optional, defaults to 3): The threshold used to determine
+        if a topic exists based on the provided llm api. Must be between 0 and 5.
     """
 
     def __init__(


### PR DESCRIPTION
This update was created due to concerns with the speed of inference. Users were getting upwards of 10 seconds or longer for a single validation call.

This update changes the functionality to use multi topic prediction. Instead of 1 transformer call per topic, it makes 1 transformer call total. 

This would most likely affect the performance (in terms of accuracy) by some degree, as it removes the detection of "other" in data input. However it still has the same generic functionality and is much more efficient. 